### PR TITLE
Allow tool to rollForward to later dotnet versions

### DIFF
--- a/PackedPrettier.csproj
+++ b/PackedPrettier.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pprettier</ToolCommandName>
+    <RollForward>major</RollForward>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageTags>prettier;dotnet</PackageTags>


### PR DESCRIPTION
If only .NET 8 is installed (common in CI scenarios) the tool won't run because it requires .NET 6 or 7. Instead of adding another target framework for .NET 8, add the `<RollForward>major</RollForward>` property to the package so that the tool can run on newer runtimes if required.

See https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward for general information about `rollForward`.

See https://github.com/dotnet/sdk/issues/10375 for additional details about rolling dotnet tools forward, and https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/721 for an example of other developer tools setting roll foward, and https://github.com/dotnet/sdk/issues/30336 for more discussion on what the defaults should be.